### PR TITLE
OPS-2973: Avoid ifup/down when adding routes and addded new options.

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -102,7 +102,7 @@ define network::interface (
   $ensure          = 'present',
   $template        = "network/interface/${::osfamily}.erb",
   $interface       = $name,
-  $restart_all_nic = true,
+  $restart_all_nic = false,
 
   $enable_dhcp     = false,
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -31,6 +31,11 @@
 #   - On RedHat: files /etc/sysconfig/network-scripts/ifcfg-${name}
 #   You can copy and adapt network/templates/interface/${::osfamily}.erb
 #
+# [*restart_all_nic*]
+#   Boolean. Default: true
+#   Manages the way to apply interface creation/modification:
+#   - If true, will trigger a restart of all network interfaces
+#   - If false, will only start/restart this specific interface
 #
 # == Debian only parameters
 #
@@ -97,6 +102,7 @@ define network::interface (
   $ensure          = 'present',
   $template        = "network/interface/${::osfamily}.erb",
   $interface       = $name,
+  $restart_all_nic = true,
 
   $enable_dhcp     = false,
 
@@ -231,6 +237,7 @@ define network::interface (
 
   validate_bool($auto)
   validate_bool($enable)
+  validate_bool($restart_all_nic)
 
   validate_array($up)
   validate_array($pre_up)
@@ -327,6 +334,19 @@ define network::interface (
 
   # Resources
 
+
+  if $restart_all_nic == false and $::kernel == 'Linux' {
+      exec { "network_restart_${name}":
+          command     => "ifdown ${name}; ifup ${name}",
+          path        => '/sbin',
+          refreshonly => true,
+      }
+      $network_notify = "Exec[network_restart_${name}]"
+  } else {
+      $network_notify = $network::manage_config_file_notify
+  }
+
+
   case $::osfamily {
 
     'Debian': {
@@ -342,13 +362,13 @@ define network::interface (
         file { "interface-${name}":
           path    => "/etc/network/interfaces.d/${name}.cfg",
           content => template($template),
-          notify  => $network::manage_config_file_notify
+          notify  => $network_notify,
         }
         if ! defined(File_line['config_file_per_interface']) {
           file_line { 'config_file_per_interface':
             path   => '/etc/network/interfaces',
             line   => 'source /etc/network/interfaces.d/*.cfg',
-            notify => $network::manage_config_file_notify,
+            notify => $network_notify,
           }
         }
       } else {
@@ -357,7 +377,7 @@ define network::interface (
             mode   => '0644',
             owner  => 'root',
             group  => 'root',
-            notify => $network::manage_config_file_notify,
+            notify => $network_notify,
           }
         }
 
@@ -385,7 +405,7 @@ define network::interface (
         mode    => '0644',
         owner   => 'root',
         group   => 'root',
-        notify  => $network::manage_config_file_notify,
+        notify  => $network_notify,
       }
     }
 
@@ -415,7 +435,7 @@ define network::interface (
         mode    => '0600',
         owner   => 'root',
         group   => 'root',
-        notify  => $network::manage_config_file_notify,
+        notify  => $network_notify,
       }
     }
 

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -78,24 +78,39 @@ define network::route (
       }
     }
     'Debian': {
-      file { "routeup-${name}":
-        ensure  => $ensure,
-        mode    => '0755',
-        owner   => 'root',
-        group   => 'root',
-        path    => "/etc/network/if-up.d/z90-route-${name}",
-        content => template('network/route_up-Debian.erb'),
-        notify  => $network::manage_config_file_notify,
-      }
-      file { "routedown-${name}":
-        ensure  => $ensure,
-        mode    => '0755',
-        owner   => 'root',
-        group   => 'root',
-        path    => "/etc/network/if-down.d/z90-route-${name}",
-        content => template('network/route_down-Debian.erb'),
-        notify  => $network::manage_config_file_notify,
-      }
+        file { "routerefresh-${name}":
+            ensure  => $ensure,
+            mode    => '0755',
+            owner   => 'root',
+            group   => 'root',
+            path    => "/etc/network/run/z90-route-refresh-${name}",
+            content => template('network/route_refresh-Debian.erb'),
+            notify => Exec['refresh-routes-${name}'],
+        }
+
+        exec { 'refresh-routes-${name}':
+            returns => [0,1,2],
+            logoutput => true,
+            command => "/bin/bash  '/etc/network/run/z90-route-refresh-${name}'",
+        }
+
+        file { "routeup-${name}":
+            ensure  => $ensure,
+            mode    => '0755',
+            owner   => 'root',
+            group   => 'root',
+            path    => "/etc/network/if-up.d/z90-route-${name}",
+            content => template('network/route_up-Debian.erb'),
+        }
+
+        file { "routedown-${name}":
+            ensure  => $ensure,
+            mode    => '0755',
+            owner   => 'root',
+            group   => 'root',
+            path    => "/etc/network/if-down.d/z90-route-${name}",
+            content => template('network/route_down-Debian.erb'),
+        }
     }
     default: { fail('Operating system not supported')  }
   }

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -3,5 +3,5 @@
 ### File managed by Puppet
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
-    sudo ip -6 route flush dev <%= @interface -%>
-    sudo ip route flush dev <%= @interface -%>
+    ip -6 route flush dev <%= @interface -%>
+    ip route flush dev <%= @interface -%>

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -5,3 +5,4 @@
 if [ "$IFACE" = "<%= @interface -%>" ]; then
     ip -6 route flush dev <%= @interface -%>
     ip route flush dev <%= @interface -%>
+fi

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -3,22 +3,5 @@
 ### File managed by Puppet
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
-<%- (0..(@ipaddress.length-1)).each do |id| -%>
-
-    ADDRESS='<%= @ipaddress[id] %>/<%= @netmask[id] %>'
-
-    if [[ $ADDRESS =~ .*:.* ]]
-    then #"IPv6"
-        if [ $ADDRESS = '0000:0000:0000:0000:0000:0000:0000:0000/0' ]
-        then
-            sudo ip -6 route del default dev <%= @interface %>
-        else
-            sudo ip -6 route del $ADDRESS dev <%= @interface %>
-
-         fi
-    else #"IPv4"
-        sudo ip route del $ADDRESS dev <%= @interface %>
-    fi
-
-<%- end -%>
-fi
+    sudo ip -6 route flush dev <%= @interface -%>
+    sudo ip route flush dev <%= @interface -%>

--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -4,6 +4,21 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %>
+
+    ADDRESS='<%= @ipaddress[id] %>/<%= @netmask[id] %>'
+
+    if [[ $ADDRESS =~ .*:.* ]]
+    then #"IPv6"
+        if [ $ADDRESS = '0000:0000:0000:0000:0000:0000:0000:0000/0' ]
+        then
+            sudo ip -6 route del default dev <%= @interface %>
+        else
+            sudo ip -6 route del $ADDRESS dev <%= @interface %>
+
+         fi
+    else #"IPv4"
+        sudo ip route del $ADDRESS dev <%= @interface %>
+    fi
+
 <%- end -%>
 fi

--- a/templates/route_refresh-Debian.erb
+++ b/templates/route_refresh-Debian.erb
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+### File managed by Puppet
+#
+
+<%- (0..(@ipaddress.length-1)).each do |id| -%>
+
+    ADDRESS='<%= @ipaddress[id] %>/<%= @netmask[id] %>'
+
+    if [[ $ADDRESS =~ .*:.* ]]
+    then #"IPv6"
+        if [ $ADDRESS = '0000:0000:0000:0000:0000:0000:0000:0000/0' ]
+        then
+            sudo ip -6 route chg default via <%= @gateway[id] %> dev <%= @interface %>
+        else
+            EXIST=`ip -6 route show $ADDRESS | wc -l`
+
+            if [ $EXIST -eq 0 ]
+            then
+                sudo ip -6 route add $ADDRESS dev <%= @interface %>
+            fi
+
+            if [ $EXIST -eq 1 ]
+            then
+                sudo ip route chg $ADDRESS dev <%= @interface %>
+            fi
+         fi
+    else #"IPv4"
+        EXIST=`ip route show $ADDRESS | wc -l`
+
+        if [ $EXIST -eq 0 ]
+        then
+            sudo ip route add $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
+        fi
+
+        if [ $EXIST -eq 1 ]
+        then
+            sudo ip route chg $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
+        fi
+    fi
+
+<%- end -%>

--- a/templates/route_refresh-Debian.erb
+++ b/templates/route_refresh-Debian.erb
@@ -11,18 +11,18 @@
     then #"IPv6"
         if [ $ADDRESS = '0000:0000:0000:0000:0000:0000:0000:0000/0' ]
         then
-            sudo ip -6 route chg default via <%= @gateway[id] %> dev <%= @interface %>
+            ip -6 route chg default via <%= @gateway[id] %> dev <%= @interface %>
         else
             EXIST=`ip -6 route show $ADDRESS | wc -l`
 
             if [ $EXIST -eq 0 ]
             then
-                sudo ip -6 route add $ADDRESS dev <%= @interface %>
+                ip -6 route add $ADDRESS dev <%= @interface %>
             fi
 
             if [ $EXIST -eq 1 ]
             then
-                sudo ip route chg $ADDRESS dev <%= @interface %>
+                ip route chg $ADDRESS dev <%= @interface %>
             fi
          fi
     else #"IPv4"
@@ -30,12 +30,12 @@
 
         if [ $EXIST -eq 0 ]
         then
-            sudo ip route add $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
+            ip route add $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
         fi
 
         if [ $EXIST -eq 1 ]
         then
-            sudo ip route chg $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
+            ip route chg $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
         fi
     fi
 

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -11,12 +11,12 @@ if [ "$IFACE" = "<%= @interface -%>" ]; then
     then #"IPv6"
         if [ $ADDRESS = '0000:0000:0000:0000:0000:0000:0000:0000/0' ]
         then
-            sudo ip -6 route add default via <%= @gateway[id] %> dev <%= @interface %>
+            ip -6 route add default via <%= @gateway[id] %> dev <%= @interface %>
         else
-            sudo ip -6 route add $ADDRESS dev <%= @interface %>
+            ip -6 route add $ADDRESS dev <%= @interface %>
          fi
     else #"IPv4"
-        sudo ip route add $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
+        ip route add $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
     fi
 
 <%- end -%>

--- a/templates/route_up-Debian.erb
+++ b/templates/route_up-Debian.erb
@@ -4,6 +4,20 @@
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
 <%- (0..(@ipaddress.length-1)).each do |id| -%>
-    ip route add <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %>
+
+    ADDRESS='<%= @ipaddress[id] %>/<%= @netmask[id] %>'
+
+    if [[ $ADDRESS =~ .*:.* ]]
+    then #"IPv6"
+        if [ $ADDRESS = '0000:0000:0000:0000:0000:0000:0000:0000/0' ]
+        then
+            sudo ip -6 route add default via <%= @gateway[id] %> dev <%= @interface %>
+        else
+            sudo ip -6 route add $ADDRESS dev <%= @interface %>
+         fi
+    else #"IPv4"
+        sudo ip route add $ADDRESS via <%= @gateway[id] %> dev <%= @interface %>
+    fi
+
 <%- end -%>
 fi


### PR DESCRIPTION
Added option to restart all NIC or not when configuring an interface.
$restart_all_nic = true, (Meaning that will restart all interfaces when configuring a given interface).

Added custom scripts to avoid ifdown/up when adding a IPv4/v6 route in hierafile, and modified existing z90ifup/ifdown generated scripts to support IPv6.