### PR TITLE
OPS-2973: Fix sintax problem.

### DIFF
--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -3,6 +3,6 @@
 ### File managed by Puppet
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
-    ip -6 route flush dev <%= @interface -%>
-    ip route flush dev <%= @interface -%>
+    ip -6 route flush dev <%= @interface %>
+    ip route flush dev <%= @interface %>
 fi


### PR DESCRIPTION
The dash "-" eliminates the '/n' character thus generating a file with all the commands in the same line