### PR TITLE
CA-554: Avoids issue with 'ip route flush' command

### DIFF
--- a/templates/route_down-Debian.erb
+++ b/templates/route_down-Debian.erb
@@ -3,6 +3,7 @@
 ### File managed by Puppet
 #
 if [ "$IFACE" = "<%= @interface -%>" ]; then
-    ip -6 route flush dev <%= @interface %>
-    ip route flush dev <%= @interface %>
+<%- (0..(@ipaddress.length-1)).each do |id| -%>
+    ip route del <%= @ipaddress[id] %>/<%= @netmask[id] %> via <%= @gateway[id] %> dev <%= @interface %>
+<%- end -%>
 fi


### PR DESCRIPTION
'ip route flush dev' is causing an issue that after issuing the command and trying to add de default route ' ip route add default via' returns an error message 'Network Unreachable' even tough the GW is reachable.
Reverting changes to prior version.